### PR TITLE
Alter return code based on whether affected or not

### DIFF
--- a/meltdown_checker.cc
+++ b/meltdown_checker.cc
@@ -262,6 +262,7 @@ static inline bool has_TSX() {
 }
 
 int main(int argc, char** argv) {
+    bool affected = false;
     g_tsx_supported = has_TSX();
 
     if (!g_tsx_supported) {
@@ -310,6 +311,7 @@ int main(int argc, char** argv) {
         if (ret) {
             std::cout << "\nSystem affected! Please consider upgrading your kernel to one that is patched with KPTI/KAISER\n";
             std::cout << "Check https://security.googleblog.com/2018/01/todays-cpu-vulnerability-what-you-need.html for more details\n";
+            affected = true;
             goto out;
         } else {
             std::cout << "so far so good (i.e. meltdown safe) ...\n";
@@ -318,5 +320,11 @@ int main(int argc, char** argv) {
     std::cout << "\nSystem not affected (take it with a grain of salt though as false negative may be reported for specific environments; " \
         "Please consider running it once again).\n";
 out:
-    return munmap(static_cast<void*>(mem), mem_size());
+    if(munmap(static_cast<void*>(mem), mem_size()) != 0) {
+        return -1;
+    }
+    if(affected) {
+        return 1;
+    }
+    return 0;
 }


### PR DESCRIPTION
It is quite handy to have this program exit with a
non-zero error code if affected (or some other issue)
happens and a zero error code if *likely* not affected.

This changes it so that a boolean is used to track
whether the system is affected (or not) and adjusts
the main() return code based on that boolean.